### PR TITLE
Start work on support for java-tables in Helix version of adlc.

### DIFF
--- a/src/main/java/au/com/helixta/adl/gradle/AdlGradlePlugin.java
+++ b/src/main/java/au/com/helixta/adl/gradle/AdlGradlePlugin.java
@@ -115,7 +115,7 @@ public class AdlGradlePlugin implements Plugin<Project>
             //Make the Java compile task depend on this if it has Java generators
             project.getTasks().named(sourceSet.getCompileJavaTaskName(), compileJavaTask ->
             {
-                if (extension.getGenerations() != null && !extension.getGenerations().getJava().isEmpty())
+                if (extension.getGenerations() != null && (!extension.getGenerations().getJava().isEmpty() || !extension.getGenerations().getJavaTables().isEmpty()))
                     compileJavaTask.dependsOn(taskName);
             });
         });

--- a/src/main/java/au/com/helixta/adl/gradle/config/GenerationsConfiguration.java
+++ b/src/main/java/au/com/helixta/adl/gradle/config/GenerationsConfiguration.java
@@ -18,6 +18,7 @@ public abstract class GenerationsConfiguration implements ExtensionAware
     private final List<JavaGenerationConfiguration> java = new ArrayList<>();
     private final List<TypescriptGenerationConfiguration> typescript = new ArrayList<>();
     private final List<JavascriptGenerationConfiguration> javascript = new ArrayList<>();
+    private final List<JavaTablesGenerationConfiguration> javaTables = new ArrayList<>();
 
     @Inject
     protected abstract ObjectFactory getObjectFactory();
@@ -40,12 +41,19 @@ public abstract class GenerationsConfiguration implements ExtensionAware
         return javascript;
     }
 
+    @Nested
+    public List<JavaTablesGenerationConfiguration> getJavaTables()
+    {
+        return javaTables;
+    }
+
     public List<? extends GenerationConfiguration> allGenerations()
     {
         List<GenerationConfiguration> all = new ArrayList<>(java.size() + typescript.size());
         all.addAll(getJava());
         all.addAll(getTypescript());
         all.addAll(getJavascript());
+        all.addAll(getJavaTables());
         return all;
     }
 
@@ -70,6 +78,13 @@ public abstract class GenerationsConfiguration implements ExtensionAware
         javascript.add(t);
     }
 
+    public void javaTables(Action<? super JavaTablesGenerationConfiguration> configuration)
+    {
+        JavaTablesGenerationConfiguration t = getObjectFactory().newInstance(JavaTablesGenerationConfiguration.class);
+        configuration.execute(t);
+        javaTables.add(t);
+    }
+
     public GenerationsConfiguration copyFrom(GenerationsConfiguration other)
     {
         for (JavaGenerationConfiguration otherConfig : other.getJava())
@@ -83,6 +98,10 @@ public abstract class GenerationsConfiguration implements ExtensionAware
         for (JavascriptGenerationConfiguration otherConfig : other.getJavascript())
         {
             this.javascript(thisConfig -> thisConfig.copyFrom(otherConfig));
+        }
+        for (JavaTablesGenerationConfiguration otherConfig : other.getJavaTables())
+        {
+            this.javaTables(thisConfig -> thisConfig.copyFrom(otherConfig));
         }
         return this;
     }

--- a/src/main/java/au/com/helixta/adl/gradle/config/JavaTablesGenerationConfiguration.java
+++ b/src/main/java/au/com/helixta/adl/gradle/config/JavaTablesGenerationConfiguration.java
@@ -1,0 +1,92 @@
+package au.com.helixta.adl.gradle.config;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+
+import java.io.File;
+
+/**
+ * Java Helix SQL tables code generation configuration for ADL.
+ */
+public abstract class JavaTablesGenerationConfiguration extends GenerationConfiguration implements ManifestGenerationSupport
+{
+    private String javaPackage;
+    private String adlRuntimePackage;
+    //TODO
+
+    private final RegularFileProperty manifest = getObjectFactory().fileProperty();
+
+    public JavaTablesGenerationConfiguration()
+    {
+        super("java");
+    }
+
+    /**
+     * @return the name of the Java package the generated code will have.
+     */
+    @Input
+    public String getJavaPackage()
+    {
+        return javaPackage;
+    }
+
+    /**
+     * Sets the name of the Java package the generated code will have.
+     */
+    public void setJavaPackage(String javaPackage)
+    {
+        this.javaPackage = javaPackage;
+    }
+
+    /**
+     * @return the language package where the ADL runtime is located.
+     */
+    @Input
+    @Optional
+    public String getAdlRuntimePackage()
+    {
+        return adlRuntimePackage;
+    }
+
+    /**
+     * Sets the language package where the ADL runtime is located.
+     */
+    public void setAdlRuntimePackage(String adlRuntimePackage)
+    {
+        this.adlRuntimePackage = adlRuntimePackage;
+    }
+
+    @Override
+    @OutputFile
+    @Optional
+    public RegularFileProperty getManifest()
+    {
+        return manifest;
+    }
+
+    /**
+     * If specified, write a manifest file recording generated files into this file.
+     */
+    public void setManifest(File manifestFile)
+    {
+        manifest.fileValue(manifestFile);
+    }
+
+    /**
+     * Deep-copy another configuration into this one.
+     *
+     * @param other the other configuration to copy.
+     *
+     * @return this configuration.
+     */
+    public JavaTablesGenerationConfiguration copyFrom(JavaTablesGenerationConfiguration other)
+    {
+        super.baseCopyFrom(other);
+        setJavaPackage(other.getJavaPackage());
+        setAdlRuntimePackage(other.getAdlRuntimePackage());
+        setManifest(other.getManifest().getAsFile().getOrNull());
+        return this;
+    }
+}

--- a/src/main/java/au/com/helixta/adl/gradle/distribution/AdlDistributionService.java
+++ b/src/main/java/au/com/helixta/adl/gradle/distribution/AdlDistributionService.java
@@ -1,21 +1,73 @@
 package au.com.helixta.adl.gradle.distribution;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.nativeplatform.platform.internal.Architectures;
 
 import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 public class AdlDistributionService extends AbstractDistributionService
 {
+    private static final String BASE_DISTRIBUTION_GROUP_ID = "org.adl.adlc";
+    private static final String DISTRIBUTION_SIMPLE_NAME = "adl";
+
+    private final Project project;
+
     public AdlDistributionService(GradleUserHomeDirProvider homeDirProvider,
                                   FileSystemOperations fileSystemOperations,
                                   ArchiveOperations archiveOperations, Project project)
     {
-        super(URI.create("https://github.com/timbod7/adl/releases/download/"), "adl", "org.adl.adlc", homeDirProvider, fileSystemOperations,
+        super(URI.create("https://github.com/timbod7/adl/releases/download/"), DISTRIBUTION_SIMPLE_NAME, homeDirProvider, fileSystemOperations,
               archiveOperations, project);
+        this.project = Objects.requireNonNull(project);
+    }
+
+    @Override
+    public URI resolveDistributionBaseUrl(DistributionSpecifier spec)
+    {
+        //Special case for Helix-specific versions - [github-repo:version]
+        ParsedVersion parsedVersion = ParsedVersion.parse(spec.getVersion());
+        if (parsedVersion != null)
+            return URI.create("https://github.com/" + parsedVersion.getGitHubRepositoryName() + "/adl/releases/download/");
+        else
+            return super.resolveDistributionBaseUrl(spec);
+    }
+
+    @Override
+    protected Dependency createDownloadDependency(DownloadParameters downloadParameters, DistributionSpecifier spec)
+    {
+        //Special case for Helix-specific versions
+        ParsedVersion parsedVersion = ParsedVersion.parse(spec.getVersion());
+        if (parsedVersion != null)
+        {
+            return project.getDependencies().create(
+                    downloadParameters.getGroupId()
+                    + ":" + downloadParameters.getArtifactId() + ":" + parsedVersion.getVersion()
+                    + ":" + downloadParameters.getClassifier() + "@" + downloadParameters.getExtension());
+        }
+        else
+            return super.createDownloadDependency(downloadParameters, spec);
+    }
+
+    @Override
+    protected String specToInstallationDirectoryName(DistributionSpecifier spec)
+    {
+        ParsedVersion parsedVersion = ParsedVersion.parse(spec.getVersion());
+        if (parsedVersion != null)
+        {
+            return DISTRIBUTION_SIMPLE_NAME + "-" + parsedVersion.getGitHubRepositoryName()
+                    + "-" + parsedVersion.getVersion()
+                    + "-" + osFamilyName(spec.getOs())
+                    + "-" + spec.getArchitecture().getName().toLowerCase(Locale.ROOT);
+        }
+        else
+            return super.specToInstallationDirectoryName(spec);
     }
 
     @Override
@@ -24,7 +76,13 @@ public class AdlDistributionService extends AbstractDistributionService
         String classifier = specToClassifier(specifier);
         if (classifier == null)
             return null;
-        return new DownloadParameters("adl-bindist", classifier, "zip");
+
+        ParsedVersion parsedVersion = ParsedVersion.parse(specifier.getVersion());
+        String groupId = BASE_DISTRIBUTION_GROUP_ID;
+        if (parsedVersion != null)
+            groupId = groupId + "." + parsedVersion.getGitHubRepositoryName();
+
+        return new DownloadParameters(groupId, "adl-bindist", classifier, "zip");
     }
 
     /**
@@ -42,5 +100,40 @@ public class AdlDistributionService extends AbstractDistributionService
 
         //No other OSes supported
         return null;
+    }
+
+    private static class ParsedVersion
+    {
+        private final String gitHubRepositoryName;
+        private final String version;
+
+        public ParsedVersion(String gitHubRepositoryName, String version)
+        {
+            this.gitHubRepositoryName = gitHubRepositoryName;
+            this.version = version;
+        }
+
+        public static ParsedVersion parse(String version)
+        {
+            if (version.contains(":"))
+            {
+                String[] versionParts = version.split(Pattern.quote(":"), 2);
+                String repoName = versionParts[0];
+                String parsedVersion = versionParts[1];
+                return new ParsedVersion(repoName, parsedVersion);
+            }
+            else
+                return null;
+        }
+
+        public String getGitHubRepositoryName()
+        {
+            return gitHubRepositoryName;
+        }
+
+        public String getVersion()
+        {
+            return version;
+        }
     }
 }

--- a/src/main/java/au/com/helixta/adl/gradle/distribution/HxAdlDistributionService.java
+++ b/src/main/java/au/com/helixta/adl/gradle/distribution/HxAdlDistributionService.java
@@ -14,7 +14,7 @@ public class HxAdlDistributionService extends AbstractDistributionService
                                     FileSystemOperations fileSystemOperations,
                                     ArchiveOperations archiveOperations, Project project)
     {
-        super(URI.create("https://github.com/helix-collective/helix-adl-tools/releases/download/"), "hxadl", "au.com.helix.adl.tools", homeDirProvider, fileSystemOperations,
+        super(URI.create("https://github.com/helix-collective/helix-adl-tools/releases/download/"), "hxadl", homeDirProvider, fileSystemOperations,
               archiveOperations, project);
     }
 
@@ -24,7 +24,7 @@ public class HxAdlDistributionService extends AbstractDistributionService
         String classifier = specToClassifier(specifier);
         if (classifier == null)
             return null;
-        return new DownloadParameters("hxadl-bindist", classifier, "zip");
+        return new DownloadParameters("au.com.helix.adl.tools", "hxadl-bindist", classifier, "zip");
     }
 
     /**


### PR DESCRIPTION
At this point, it is able to add `javaTables` to the `generations` block and have it invoke.

```
adl {
    version = "helix-collective:1.1.4"
    generations {
        java {
            javaPackage  = "adl.tester"
            isGenerateTransitive = true
            isGenerateAdlRuntime = true
            headerComment = "This is ADL"

        }

        javaTables {
            javaPackage = "adl.tester.tables"
        }
    }
}
```

There are currently issues with mising ADL search directories for both the core stuff (sys.annotations) and the db stuff (common.db).  I have worked around these in my example project by manually adding these by adding dependencies:

```
    adlSearchDirectories(files("/home/prunge/.gradle/adl/adl-helix-collective-1.1.4-linux-x86-64/lib/adl/"))
    adlSearchDirectories(files("$projectDir/adllib"))
```

but this is a workaround/hack.